### PR TITLE
Feat/create lazy params for embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ When instantiating `Flat.Embed`, you can pass options in the second parameter. T
 | `width`       | The width of your embed                             | A width of the embed                                                            | `100%`  |
 | `height`      | The height of your embed                            | A height of the embed                                                           | `100%`  |
 | `embedParams` | Object containing the loading options for the embed | [Any URL parameters](https://flat.io/developers/docs/embed/url-parameters.html) | `{}`    |
+| `lazy`        | Add a `loading="lazy"` attribute to the iframe      | A boolean to enable the lazy-loading                                            | `false` |
 
 ## JavaScript API
 

--- a/src/lib/embed.ts
+++ b/src/lib/embed.ts
@@ -46,6 +46,10 @@ export function createEmbedIframe(
   iframe.setAttribute('allow', 'autoplay; midi');
   iframe.setAttribute('frameborder', '0');
 
+  if (parameters.lazy) {
+    iframe.setAttribute('loading', 'lazy');
+  }
+
   element.appendChild(iframe);
 
   return iframe;

--- a/src/types/embedParameters.ts
+++ b/src/types/embedParameters.ts
@@ -199,6 +199,9 @@ export interface EmbedParameters {
   /** Base URL for the embed */
   baseUrl?: string;
 
+  /** Lazy loading of the iframe */
+  lazy?: boolean;
+
   /**
    * Optional configuration and customization options
    * See https://flat.io/developers/docs/embed/url-parameters for more details

--- a/test/unit/embed.js
+++ b/test/unit/embed.js
@@ -161,5 +161,16 @@ describe('Unit - Embed tests', () => {
       assert.equal(embed.element.getAttribute('frameborder'), '0');
       container.removeChild(embed.element);
     });
+
+    it('should use the lazy loading attribute', () => {
+      const container = document.getElementById('container');
+      const embed = new Flat.Embed(container, {
+        score: '1234',
+        lazy: true,
+      });
+      assert.equal(embed.element.getAttribute('src'), 'https://flat-embed.com/1234?jsapi=true');
+      assert.equal(embed.element.getAttribute('loading'), 'lazy');
+      container.removeChild(embed.element);
+    });
   });
 });


### PR DESCRIPTION
Create `lazy` parameter to add a `loading="lazy"` on the the iframe.

| Option        | Description                                         | Values                                                                          | Default |
| :------------ | :-------------------------------------------------- | :------------------------------------------------------------------------------ | :------ |
| `lazy`        | Add a `loading="lazy"` attribute to the iframe      | A boolean to enable the lazy-loading                                            | `false` |