### PR TITLE
chore: Add npm script for docs generation and use realistic UUIDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "prettier:write": "prettier --write .",
     "test:karma": "karma start --single-run",
     "test:karma-watch": "karma start --single-run=false --auto-watch",
-    "prepare": "husky"
+    "prepare": "husky",
+    "generate:docs": "npx tsx scripts/generate-api-docs.ts"
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown",

--- a/scripts/generate-api-docs.ts
+++ b/scripts/generate-api-docs.ts
@@ -296,11 +296,11 @@ ${method.signature}
               let value = '';
               if (propType.includes('string')) {
                 if (propName === 'partUuid') {
-                  value = "'part-123-uuid'";
+                  value = "'00000000-0000-0000-0000-000000000001'";
                 } else if (propName === 'measureUuid') {
-                  value = "'measure-456-uuid'";
+                  value = "'00000000-0000-0000-0000-000000000002'";
                 } else if (propName === 'voiceUuid') {
-                  value = "'voice-789-uuid'";
+                  value = "'00000000-0000-0000-0000-000000000003'";
                 } else if (propName === 'id') {
                   value = "'track-id'";
                 } else if (propName === 'score') {
@@ -346,7 +346,7 @@ ${method.signature}
       if (p.type.includes('string')) {
         if (p.name === 'score') return `'5ce6a27f052b2a74a91f4a6d'`;
         if (p.name === 'event') return `'play'`;
-        if (p.name === 'partUuid') return `'part-123-uuid'`;
+        if (p.name === 'partUuid') return `'00000000-0000-0000-0000-000000000001'`;
         if (p.name === 'mode') return `'edit'`;
         return `'value'`;
       }


### PR DESCRIPTION
- Add 'generate:docs' npm script to easily regenerate API documentation
- Update example UUIDs to use proper UUID format (00000000-0000-0000-0000-00000000000X)
- Use npx to run tsx for better compatibility