### PR TITLE
feat: add editorInterface to EmbedUrlParameters type

### DIFF
--- a/src/types/embedParameters.ts
+++ b/src/types/embedParameters.ts
@@ -144,6 +144,9 @@ export interface EmbedUrlParameters {
   /** Display or hide main controls (default = true) */
   controlsDisplay?: boolean;
 
+  /** Editor interface style (default = desktop) */
+  editorInterface?: 'desktop' | 'mobile';
+
   /** Controls position (default = bottom) */
   controlsPosition?: 'bottom' | 'top';
 


### PR DESCRIPTION
## Summary
- Adds `editorInterface` parameter (`'desktop' | 'mobile'`) to `EmbedUrlParameters` TypeScript type
- This parameter was already supported by the embed app but missing from the SDK types

## Test plan
- [ ] Verify TypeScript types compile correctly
- [ ] Verify `editorInterface: 'mobile'` is accepted by the SDK without type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)